### PR TITLE
Fix unassigned _parent

### DIFF
--- a/addons/AsyncSceneManager/async_scene.gd
+++ b/addons/AsyncSceneManager/async_scene.gd
@@ -137,6 +137,7 @@ func _init(
 	_packed_scene_path = tscn_path
 	_operation = set_operation
 	_current_scene = current_scene
+	_parent = parent
 
 
 ## Starts the loading process. [br]


### PR DESCRIPTION
Made a mistake in the previous PR, just noticed it because I tried to use it in my own project.

I did not assign `_parent` in `_init()`, which made that whole part of my code just not engage.
Fixed it, and tested it on 4.5.1, everything works now.